### PR TITLE
"Added restrict-main-merge.yml to prevent merge from feat to main "

### DIFF
--- a/.github/workflows/restrict-main-merge.yml
+++ b/.github/workflows/restrict-main-merge.yml
@@ -1,0 +1,18 @@
+name: Restrict Main Branch Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if PR is from dev branch
+        run: |
+          if [[ "${{ github.event.pull_request.head.ref }}" != "dev" ]]; then
+            echo "❌ Error: Only pull requests from 'dev' branch can be merged into 'main'."
+            exit 1
+          fi


### PR DESCRIPTION
## 📌 Feature Description
- CI/CD로 feat -> main 브랜치로 병합시 실패 결과를 내놓도록 `restrict-main-merge.yml` 파일을 작성하였습니다. 
- RuleSet만으로 dev 브랜치에서만 병합할 수있도록 제한할 수 없어서 작성하였습니다. 

## 🔧 Implementation Details

### restrict-main-merge.yml
- github action 활용하여 CI를 진행하기 위하여 레포지토리의 Settings > branch > Add a ruleset > 'Require Status Checks' 가 선행되어야 합니다. 

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
- None
