### PR TITLE
To fix KtlintError, Rename toy_team6_airbnb -> toyTeam6AirBnb (CamelCase)

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/22-5-team6-server.iml" filepath="$PROJECT_DIR$/.idea/22-5-team6-server.iml" />
-    </modules>
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# 22-5-team6-server
+# 22-5-team6-serverTemporary change for PR

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "toy_team6_airbnb"
+rootProject.name = "toyTeam6Airbnb"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,11 @@
+# Kotlin JAR 빌드
+FROM openjdk:17-jdk-alpine
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 빌드 결과물 복사
+COPY build/libs/*.jar app.jar
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/ToyTeam6AirbnbApplication.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/ToyTeam6AirbnbApplication.kt
@@ -1,4 +1,4 @@
-package com.example.toy_team6_airbnb
+package com.example.toyTeam6Airbnb
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ToyTeam6AirbnbApplicationTests.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ToyTeam6AirbnbApplicationTests.kt
@@ -1,4 +1,5 @@
-package com.example.toy_team6_airbnb
+
+package com.example.toyTeam6Airbnb
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -9,5 +10,4 @@ class ToyTeam6AirbnbApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }


### PR DESCRIPTION
## 📌 Feature Description
CI 과정에서 Ktlint Error 원인이 Package name에 underscore여서, packageName을 `toyTeam6Airbnb` 로 수정하였습니다  
`settings.gradle.kts` : rootProject name 수정
`toyTeam6Airbnb.main` , `toyTeam6AirbnbTest` 폴더 명 수정


## 🔧 Implementation Details
- `ToyTeam6AirbnbApplicationTests.kt` : ktLint 테스트 통과를 위해
ToyTeam6AirbnbApplicationTests.kt:12:1 Unexpected blank line(s) before "}"
반영하여 수정 

조금 이상한 부분이 
```

package com.example.toyTeam6Airbnb

import org.junit.jupiter.api.Test
import org.springframework.boot.test.context.SpringBootTest

@SpringBootTest
class ToyTeam6AirbnbApplicationTests {

    @Test
    fun contextLoads() {
    }
}

```
마지막 개행에 enterLine이 하나 들어가고, 맨 상단에도 enterline이 반영되었습니다.
그럼에도 `./gradlew ktlintCheck` 가 통과되었는데 마지막 개행은 없어지는게 맞는 방향인 것 같습니다. 


## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
None
