### PR TITLE
Allow test server to return bearer token directly

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
@@ -3,13 +3,16 @@ package com.example.toyTeam6Airbnb.config
 import com.example.toyTeam6Airbnb.user.JwtTokenProvider
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 import org.springframework.stereotype.Component
 
 @Component
 class CustomAuthenticationSuccessHandler(
-    private val jwtTokenProvider: JwtTokenProvider
+    private val jwtTokenProvider: JwtTokenProvider,
+    @Value("\${spring.profiles.active}")
+    private val profile: String
 ) : SimpleUrlAuthenticationSuccessHandler() {
 
     override fun onAuthenticationSuccess(
@@ -19,6 +22,6 @@ class CustomAuthenticationSuccessHandler(
     ) {
         val token = jwtTokenProvider.generateToken(authentication.name)
         response.addHeader("Authorization", "Bearer $token")
-        // response.sendRedirect("/redirect#token=$token")
+        if(profile == "dev") response.sendRedirect("/redirect#token=$token")
     }
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
@@ -22,6 +22,6 @@ class CustomAuthenticationSuccessHandler(
     ) {
         val token = jwtTokenProvider.generateToken(authentication.name)
         response.addHeader("Authorization", "Bearer $token")
-        if(profile == "dev") response.sendRedirect("/redirect#token=$token")
+        if (profile == "prod") response.sendRedirect("/redirect#token=$token")
     }
 }


### PR DESCRIPTION
## 📌 Feature Description
실제 서버에서는 authentication 이후 redirect가 되어야 합니다.
그러나 테스트 서버에서는 token을 바로 받는 것이 편합니다.
spring active profile을 이용하여 이를 구현하였습니다.
실제 서버 `application.yaml`에 `spring.profiles.active: prod` 설정만 해주면 됩니다.(추가해 놓았습니다.)

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1
- [ ] 주요 변경사항 2
- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [x] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
