### PR TITLE
Reservation API (인원 고려) 및 순환참조 에러 해결 

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/ReservationException.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/ReservationException.kt
@@ -34,3 +34,9 @@ class MaxOccupancyExceeded : ReservationException(
     httpStatusCode = HttpStatus.CONFLICT,
     msg = "Max Occupancy Exceeded"
 )
+
+class ZeroGuests : ReservationException(
+    errorCode = 4005,
+    httpStatusCode = HttpStatus.BAD_REQUEST,
+    msg = "Number of Guests should be more than 0"
+)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/ReservationException.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/ReservationException.kt
@@ -12,19 +12,25 @@ sealed class ReservationException(
 ) : DomainException(errorCode, httpStatusCode, msg, cause)
 
 class ReservationUnavailable : ReservationException(
-    errorCode = 1009,
+    errorCode = 4001,
     httpStatusCode = HttpStatus.CONFLICT,
     msg = "Reservation is not Available"
 )
 
 class ReservationNotFound : ReservationException(
-    errorCode = 1010,
+    errorCode = 4002,
     httpStatusCode = HttpStatus.NOT_FOUND,
     msg = "Reservation doesn't exist"
 )
 
 class ReservationPermissionDenied : ReservationException(
-    errorCode = 1011,
+    errorCode = 4003,
     httpStatusCode = HttpStatus.FORBIDDEN,
     msg = "Permission Denied"
+)
+
+class MaxOccupancyExceeded : ReservationException(
+    errorCode = 4004,
+    httpStatusCode = HttpStatus.CONFLICT,
+    msg = "Max Occupancy Exceeded"
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
@@ -1,17 +1,14 @@
 package com.example.toyTeam6Airbnb.reservation.controller
 
 import com.example.toyTeam6Airbnb.reservation.persistence.ReservationEntity
-import com.example.toyTeam6Airbnb.review.controller.Review
-import com.example.toyTeam6Airbnb.room.controller.Room
-import com.example.toyTeam6Airbnb.user.controller.User
 import java.time.Instant
 import java.time.LocalDate
 
 data class Reservation(
     val id: Long,
-    val user: User,
-    val room: Room,
-    val review: Review?,
+    val userId: Long,
+    val roomId: Long,
+    val reviewId: Long?,
     val startDate: LocalDate,
     val endDate: LocalDate,
     val totalPrice: Double,
@@ -22,9 +19,9 @@ data class Reservation(
         fun fromEntity(entity: ReservationEntity): Reservation {
             return Reservation(
                 id = entity.id!!,
-                user = User.fromEntity(entity.user),
-                room = Room.fromEntity(entity.room),
-                review = entity.review?.let { Review.fromEntity(it) },
+                userId = entity.user.id!!,
+                roomId = entity.room.id!!,
+                reviewId = entity.review?.id,
                 startDate = entity.startDate,
                 endDate = entity.endDate,
                 totalPrice = entity.totalPrice,
@@ -37,16 +34,14 @@ data class Reservation(
     fun toDTO(): ReservationDTO {
         return ReservationDTO(
             id = this.id,
-            userId = this.user.id,
-            roomId = this.room.id,
+            userId = this.userId,
+            roomId = this.roomId,
             startDate = this.startDate,
             endDate = this.endDate
         )
     }
 }
 
-// Reservation DTO
-// 추후, 가격이나 특정 프로퍼티 추가할 수 있음.
 data class ReservationDTO(
     val id: Long,
     val roomId: Long,

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
@@ -12,6 +12,7 @@ data class Reservation(
     val startDate: LocalDate,
     val endDate: LocalDate,
     val totalPrice: Double,
+    val numberofGuests : Int,
     val createdAt: Instant,
     val updatedAt: Instant
 ) {
@@ -26,7 +27,8 @@ data class Reservation(
                 endDate = entity.endDate,
                 totalPrice = entity.totalPrice,
                 createdAt = entity.createdAt,
-                updatedAt = entity.updatedAt
+                updatedAt = entity.updatedAt,
+                numberofGuests = entity.numberOfGuests
             )
         }
     }
@@ -37,7 +39,8 @@ data class Reservation(
             userId = this.userId,
             roomId = this.roomId,
             startDate = this.startDate,
-            endDate = this.endDate
+            endDate = this.endDate,
+            numberOfGuests = this.numberofGuests
         )
     }
 }
@@ -47,5 +50,6 @@ data class ReservationDTO(
     val roomId: Long,
     val userId: Long,
     val startDate: LocalDate,
-    val endDate: LocalDate
+    val endDate: LocalDate,
+    val numberOfGuests : Int
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/Reservation.kt
@@ -12,7 +12,7 @@ data class Reservation(
     val startDate: LocalDate,
     val endDate: LocalDate,
     val totalPrice: Double,
-    val numberofGuests : Int,
+    val numberofGuests: Int,
     val createdAt: Instant,
     val updatedAt: Instant
 ) {
@@ -51,5 +51,5 @@ data class ReservationDTO(
     val userId: Long,
     val startDate: LocalDate,
     val endDate: LocalDate,
-    val numberOfGuests : Int
+    val numberOfGuests: Int
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
@@ -143,7 +143,7 @@ class CreateReservationRequest(
     val roomId: Long,
     val startDate: LocalDate,
     val endDate: LocalDate,
-    val numberOfGuests : Int
+    val numberOfGuests: Int
 )
 
 class UpdateReservationRequest(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
@@ -37,7 +37,8 @@ class ReservationController(
             User.fromEntity(principalDetails.getUser()),
             request.roomId,
             request.startDate,
-            request.endDate
+            request.endDate,
+            request.numberOfGuests
         )
 
         return ResponseEntity.status(HttpStatus.CREATED).body(reservation.toDTO())
@@ -68,7 +69,8 @@ class ReservationController(
             User.fromEntity(principalDetails.getUser()),
             reservationId,
             request.startDate,
-            request.endDate
+            request.endDate,
+            request.numberOfGuests
         )
 
         return ResponseEntity.ok().body(reservation.toDTO())
@@ -96,29 +98,29 @@ class ReservationController(
         return ResponseEntity.ok(reservations)
     }
 
-    // 특정 room의 reservation을 모두 가져오는 API
-    @GetMapping("/room/{roomId}")
-    fun getReservationsByRoom(
-        @PathVariable roomId: Long
-    ): ResponseEntity<List<ReservationDTO>> {
-        val reservations = reservationService.getReservationsByRoom(roomId).map { it.toDTO() }
+//    // 특정 room의 reservation을 모두 가져오는 API
+//    @GetMapping("/room/{roomId}")
+//    fun getReservationsByRoom(
+//        @PathVariable roomId: Long
+//    ): ResponseEntity<List<ReservationDTO>> {
+//        val reservations = reservationService.getReservationsByRoom(roomId).map { it.toDTO() }
+//
+//        return ResponseEntity.ok().body(reservations)
+//    }
 
-        return ResponseEntity.ok().body(reservations)
-    }
-
-    // 특정 date range의 reservation을 모두 가져오는 API
-    @GetMapping("/date")
-    fun getReservationsByDate(
-        @RequestParam startDate: String,
-        @RequestParam endDate: String
-    ): ResponseEntity<List<ReservationDTO>> {
-        val reservations = reservationService.getReservationsByDate(
-            LocalDate.parse(startDate),
-            LocalDate.parse(endDate)
-        ).map { it.toDTO() }
-
-        return ResponseEntity.ok().body(reservations)
-    }
+//    // 특정 date range의 reservation을 모두 가져오는 API
+//    @GetMapping("/date")
+//    fun getReservationsByDate(
+//        @RequestParam startDate: String,
+//        @RequestParam endDate: String
+//    ): ResponseEntity<List<ReservationDTO>> {
+//        val reservations = reservationService.getReservationsByDate(
+//            LocalDate.parse(startDate),
+//            LocalDate.parse(endDate)
+//        ).map { it.toDTO() }
+//
+//        return ResponseEntity.ok().body(reservations)
+//    }
 
     // 특정 room의 특정 month의 available/unavailable date를 가져오는 API
     @GetMapping("/availability/{roomId}")
@@ -140,12 +142,14 @@ class ReservationController(
 class CreateReservationRequest(
     val roomId: Long,
     val startDate: LocalDate,
-    val endDate: LocalDate
+    val endDate: LocalDate,
+    val numberOfGuests : Int
 )
 
 class UpdateReservationRequest(
     val startDate: LocalDate,
-    val endDate: LocalDate
+    val endDate: LocalDate,
+    val numberOfGuests: Int
 )
 
 // 특정 방의 예약 가능날짜와 불가능한 날짜 반환 DTO

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationEntity.kt
@@ -34,7 +34,7 @@ class ReservationEntity(
     @JoinColumn(name = "room_id", nullable = false)
     val room: RoomEntity,
 
-    @OneToOne(mappedBy = "reservation", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToOne(mappedBy = "reservation", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
     val review: ReviewEntity?,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationEntity.kt
@@ -50,7 +50,11 @@ class ReservationEntity(
     var createdAt: Instant = Instant.now(),
 
     @Column(nullable = false)
-    var updatedAt: Instant = Instant.now()
+    var updatedAt: Instant = Instant.now(),
+
+    @Column(nullable = false)
+    var numberOfGuests: Int
+
 ) {
     @PrePersist
     fun onPrePersist() {

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
@@ -12,7 +12,8 @@ interface ReservationService {
         user: User,
         roomId: Long,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        numberOfGuests: Int
     ): Reservation
 
     fun deleteReservation(
@@ -24,7 +25,9 @@ interface ReservationService {
         user: User,
         reservationId: Long,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        numberOfGuests: Int
+
     ): Reservation
 
     fun getReservation(
@@ -35,14 +38,14 @@ interface ReservationService {
         user: User
     ): List<Reservation>
 
-    fun getReservationsByRoom(
-        roomId: Long
-    ): List<Reservation>
-
-    fun getReservationsByDate(
-        startDate: LocalDate,
-        endDate: LocalDate
-    ): List<Reservation>
+//    fun getReservationsByRoom(
+//        roomId: Long
+//    ): List<Reservation>
+//
+//    fun getReservationsByDate(
+//        startDate: LocalDate,
+//        endDate: LocalDate
+//    ): List<Reservation>
 
     fun getAvailabilityByMonth(roomId: Long, yearMonth: YearMonth): RoomAvailabilityResponse
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -1,6 +1,10 @@
 package com.example.toyTeam6Airbnb.reservation.service
 
-import com.example.toyTeam6Airbnb.reservation.*
+import com.example.toyTeam6Airbnb.reservation.MaxOccupancyExceeded
+import com.example.toyTeam6Airbnb.reservation.ReservationNotFound
+import com.example.toyTeam6Airbnb.reservation.ReservationPermissionDenied
+import com.example.toyTeam6Airbnb.reservation.ReservationUnavailable
+import com.example.toyTeam6Airbnb.reservation.ZeroGuests
 import com.example.toyTeam6Airbnb.reservation.controller.Reservation
 import com.example.toyTeam6Airbnb.reservation.controller.RoomAvailabilityResponse
 import com.example.toyTeam6Airbnb.reservation.persistence.ReservationEntity
@@ -31,7 +35,7 @@ class ReservationServiceImpl(
         roomId: Long,
         startDate: LocalDate,
         endDate: LocalDate,
-        numberOfGuests : Int
+        numberOfGuests: Int
     ): Reservation {
         val userEntity = userRepository.findByIdOrNull(user.id) ?: throw AuthenticateException()
         val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -1,8 +1,6 @@
 package com.example.toyTeam6Airbnb.reservation.service
 
-import com.example.toyTeam6Airbnb.reservation.ReservationNotFound
-import com.example.toyTeam6Airbnb.reservation.ReservationPermissionDenied
-import com.example.toyTeam6Airbnb.reservation.ReservationUnavailable
+import com.example.toyTeam6Airbnb.reservation.*
 import com.example.toyTeam6Airbnb.reservation.controller.Reservation
 import com.example.toyTeam6Airbnb.reservation.controller.RoomAvailabilityResponse
 import com.example.toyTeam6Airbnb.reservation.persistence.ReservationEntity
@@ -32,12 +30,19 @@ class ReservationServiceImpl(
         user: User,
         roomId: Long,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        numberOfGuests : Int
     ): Reservation {
         val userEntity = userRepository.findByIdOrNull(user.id) ?: throw AuthenticateException()
         val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
 
         if (!isAvailable(roomEntity, startDate, endDate)) throw ReservationUnavailable()
+
+        // 예약 인원수가 초과할 경우 예외 발생
+        if (numberOfGuests > roomEntity.maxOccupancy) throw MaxOccupancyExceeded()
+
+        // 예약 인원이 0명인 경우 예외 발생
+        if (numberOfGuests == 0) throw ZeroGuests()
 
         val reservationEntity = ReservationEntity(
             user = userEntity,
@@ -45,7 +50,8 @@ class ReservationServiceImpl(
             review = null,
             startDate = startDate,
             endDate = endDate,
-            totalPrice = roomEntity.price * ChronoUnit.DAYS.between(startDate, endDate)
+            totalPrice = roomEntity.price * ChronoUnit.DAYS.between(startDate, endDate),
+            numberOfGuests = numberOfGuests
         ).let {
             reservationRepository.save(it)
         }
@@ -79,7 +85,8 @@ class ReservationServiceImpl(
         user: User,
         reservationId: Long,
         startDate: LocalDate,
-        endDate: LocalDate
+        endDate: LocalDate,
+        numberOfGuests: Int
     ): Reservation {
         val userEntity = userRepository.findByIdOrNull(user.id) ?: throw AuthenticateException()
         val reservationEntity = reservationRepository.findByIdOrNull(reservationId) ?: throw ReservationNotFound()
@@ -89,9 +96,13 @@ class ReservationServiceImpl(
 
         if (!isAvailable(roomEntity, startDate, endDate, reservationEntity.id)) throw ReservationUnavailable()
 
+        if (numberOfGuests > roomEntity.maxOccupancy) throw MaxOccupancyExceeded()
+        if (numberOfGuests == 0) throw ZeroGuests()
+
         reservationEntity.startDate = startDate
         reservationEntity.endDate = endDate
         reservationEntity.totalPrice = roomEntity.price * ChronoUnit.DAYS.between(startDate, endDate)
+        reservationEntity.numberOfGuests = numberOfGuests
         reservationRepository.save(reservationEntity)
 
         return Reservation.fromEntity(reservationEntity)
@@ -111,21 +122,21 @@ class ReservationServiceImpl(
         return reservationRepository.findAllByUser(userEntity).map(Reservation::fromEntity)
     }
 
-    @Transactional
-    override fun getReservationsByRoom(roomId: Long): List<Reservation> {
-        val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
+//    @Transactional
+//    override fun getReservationsByRoom(roomId: Long): List<Reservation> {
+//        val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
+//
+//        return reservationRepository.findAllByRoom(roomEntity).map(Reservation::fromEntity)
+//    }
 
-        return reservationRepository.findAllByRoom(roomEntity).map(Reservation::fromEntity)
-    }
-
-    @Transactional
-    override fun getReservationsByDate(startDate: LocalDate, endDate: LocalDate): List<Reservation> {
-        val reservations = reservationRepository.findAll().filter { reservation ->
-            startDate < reservation.endDate && endDate > reservation.startDate
-        }
-
-        return reservations.map(Reservation::fromEntity)
-    }
+//    @Transactional
+//    override fun getReservationsByDate(startDate: LocalDate, endDate: LocalDate): List<Reservation> {
+//        val reservations = reservationRepository.findAll().filter { reservation ->
+//            startDate < reservation.endDate && endDate > reservation.startDate
+//        }
+//
+//        return reservations.map(Reservation::fromEntity)
+//    }
 
     // 특정 방의 해당 월의 예약 가능한 날짜와 예약 불가능한 날짜를 가져오는 API를 위한 서비스 로직
     @Transactional

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/ReviewException.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/ReviewException.kt
@@ -12,13 +12,13 @@ sealed class ReviewException(
 ) : DomainException(errorCode, httpStatusCode, msg, cause)
 
 class ReviewNotFound : ReviewException(
-    errorCode = 1012,
+    errorCode = 3001,
     httpStatusCode = HttpStatus.CONFLICT,
     msg = "Review doesn't exist"
 )
 
 class ReviewPermissionDenied : ReviewException(
-    errorCode = 1013,
+    errorCode = 3002,
     httpStatusCode = HttpStatus.FORBIDDEN,
     msg = "Permission Denied"
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/Review.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/Review.kt
@@ -1,16 +1,13 @@
 package com.example.toyTeam6Airbnb.review.controller
 
-import com.example.toyTeam6Airbnb.reservation.controller.Reservation
 import com.example.toyTeam6Airbnb.review.persistence.ReviewEntity
-import com.example.toyTeam6Airbnb.room.controller.Room
-import com.example.toyTeam6Airbnb.user.controller.User
 import java.time.Instant
 
 data class Review(
     val id: Long,
-    val user: User,
-    val reservation: Reservation,
-    val room: Room,
+    val userId: Long,
+    val reservationId: Long,
+    val roomId: Long,
     val content: String,
     val rating: Int,
     val createdAt: Instant,
@@ -20,9 +17,9 @@ data class Review(
         fun fromEntity(entity: ReviewEntity): Review {
             return Review(
                 id = entity.id!!,
-                user = User.fromEntity(entity.user),
-                reservation = Reservation.fromEntity(entity.reservation),
-                room = Room.fromEntity(entity.room),
+                userId = entity.user.id!!,
+                reservationId = entity.reservation.id!!,
+                roomId = entity.room.id!!,
                 content = entity.content,
                 rating = entity.rating,
                 createdAt = entity.createdAt,
@@ -31,13 +28,12 @@ data class Review(
         }
     }
 
-    // toDTO() 추가
     fun toDTO(): ReviewDTO {
         return ReviewDTO(
             id = this.id,
-            userId = this.user.id,
-            reservationId = this.reservation.id,
-            roomId = this.room.id,
+            userId = this.userId,
+            reservationId = this.reservationId,
+            roomId = this.roomId,
             content = this.content,
             rating = this.rating
         )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/RoomException.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/RoomException.kt
@@ -12,13 +12,13 @@ sealed class RoomException(
 ) : DomainException(errorCode, httpStatusCode, msg, cause)
 
 class RoomNotFoundException : RoomException(
-    errorCode = 1007,
+    errorCode = 2001,
     httpStatusCode = HttpStatus.NOT_FOUND,
     msg = "Room does not exist"
 )
 
 class RoomPermissionDeniedException : RoomException(
-    errorCode = 1008,
+    errorCode = 2002,
     httpStatusCode = HttpStatus.FORBIDDEN,
     msg = "Permission denied"
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
@@ -5,7 +5,7 @@ import java.time.Instant
 
 data class Room(
     val id: Long,
-    val host: UserEntity,
+    val hostId: Long,
     val name: String,
     val description: String,
     val type: String,
@@ -19,7 +19,7 @@ data class Room(
         fun fromEntity(entity: com.example.toyTeam6Airbnb.room.persistence.RoomEntity): Room {
             return Room(
                 id = entity.id!!,
-                host = entity.host,
+                hostId = entity.host.id!!,
                 name = entity.name,
                 description = entity.description,
                 type = entity.type,
@@ -34,7 +34,7 @@ data class Room(
     fun toDTO(): RoomDTO {
         return RoomDTO(
             id = this.id,
-            hostId = this.host.id!!,
+            hostId = this.hostId,
             name = this.name,
             description = this.description,
             type = this.type,

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
@@ -1,6 +1,5 @@
 package com.example.toyTeam6Airbnb.room.controller
 
-import com.example.toyTeam6Airbnb.user.persistence.UserEntity
 import java.time.Instant
 
 data class Room(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/User.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/User.kt
@@ -20,4 +20,16 @@ data class User(
             )
         }
     }
+
+    fun toDTO(): UserDTO {
+        return UserDTO(
+            id = this.id,
+            username = this.username
+        )
+    }
 }
+
+data class UserDTO(
+    val id: Long,
+    val username: String
+)


### PR DESCRIPTION
## 📌 Feature Description
<!-- 이번 PR에서 추가된 기능의 상세 설명을 작성해주세요. -->
1. DTO 순환참조 오류 해결
2. Exception Error code 수정 및 추가
3. Reservation에 numberOfGuests 필드 추가 및 예약 인원 고려 로직 구현

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1) DTO 순환참조 오류 해결
data class Review, Reservation 생성 시에 
`review = entity.review?.let { Review.fromEntity(it) }`
에서 서로 순환참조가 재귀적으로 발생하는 오류가 생겼습니다.
이를 수정하고자 Room, User, Reservation, Review에서 data class에서 연관관계는 모두 id를 참조하도록 수정하였습니다.
이로인해 Controller에서 id를 받아서 서비스로직에서 엔티티를 찾고 정보를 더 전달해야하는 번거로움은 있을 것으로 보이긴 합니다
(향후 불편함 발생시 DTO 구조 수정 필요)

- [ ] 주요 변경사항 2) Exception 파일
Exception 코드가 1001, 1002, ... 식이여서 하나가 수정될때마다 다른파일도 다수정해야해서
앞자리를 User, Room 등등에 따라 1,2,3,4,5 앞자리를 바꿨습니다.
또한 ReservationException에서 게스트 수에 따른 예외도 2개 추가하였습니다.

- [ ] 주요 변경사항 3) numberOfGuests 추가
API 요청 사항으로 예약 인원수를 반영하고자
엔티티, DTO, Service, Controller를 수정하였습니다.
로직은 엔티티로부터 numberOfGuests를 받아와 Room의 MaxOccupancy 필드와 비교하여 최대 수용인원 이내, 
예약 인원수가 0이 아닐때만 예약이 형성되도록 설정하였습니다
-> Room에서도 MaxOccupancy 처음에 입력받을때 1이상으로 되도록 해야할 것 같습니다. 

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
