### PR TITLE
Created user profile API

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/Profile.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/Profile.kt
@@ -1,3 +1,19 @@
 package com.example.toyTeam6Airbnb.profile.controller
 
-class Profile
+import com.example.toyTeam6Airbnb.profile.persistence.ProfileEntity
+
+data class Profile(
+    val id: Long,
+    val userId: Long,
+    val nickname: String
+) {
+    companion object {
+        fun fromEntity(profileEntity: ProfileEntity): Profile {
+            return Profile(
+                id = profileEntity.id,
+                userId = profileEntity.user.id!!,
+                nickname = profileEntity.nickname
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/ProfileController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/ProfileController.kt
@@ -1,8 +1,55 @@
 package com.example.toyTeam6Airbnb.profile.controller
 
+import com.example.toyTeam6Airbnb.profile.service.ProfileService
+import com.example.toyTeam6Airbnb.user.controller.PrincipalDetails
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/v1")
-class ProfileController
+@RequestMapping("/api/v1/profile")
+@Tag(name = "Profile Controller", description = "Profile Controller API")
+class ProfileController(
+    private val profileService: ProfileService
+) {
+
+    @GetMapping
+    @Operation(summary = "Get User Profile", description = "Get the profile of the current user")
+    fun getCurrentUserProfile(@AuthenticationPrincipal principalDetails: PrincipalDetails): ResponseEntity<Profile> {
+        val profile = profileService.getCurrentUserProfile(principalDetails.getUser())
+        return if (profile != null) {
+            ResponseEntity.ok(Profile.fromEntity(profile))
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    @PutMapping
+    @Operation(summary = "Update User Profile", description = "Update the profile of the current user")
+    fun updateCurrentUserProfile(@AuthenticationPrincipal principalDetails: PrincipalDetails, @RequestBody request: UpdateProfileRequest): ResponseEntity<Profile> {
+        val updatedProfile = profileService.updateCurrentUserProfile(principalDetails.getUser(), request)
+        return ResponseEntity.ok(Profile.fromEntity(updatedProfile))
+    }
+
+    @PostMapping
+    @Operation(summary = "Add Profile to User", description = "Add a profile to the current user, only for users logged in with social login")
+    fun addProfileToCurrentUser(@AuthenticationPrincipal principalDetails: PrincipalDetails, @RequestBody request: CreateProfileRequest): ResponseEntity<Profile> {
+        val newProfile = profileService.addProfileToCurrentUser(principalDetails.getUser(), request)
+        return ResponseEntity.status(201).body(Profile.fromEntity(newProfile))
+    }
+}
+
+data class UpdateProfileRequest(
+    val nickname: String
+)
+
+data class CreateProfileRequest(
+    val nickname: String
+)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileEntity.kt
@@ -1,6 +1,7 @@
 package com.example.toyTeam6Airbnb.profile.persistence
 
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
@@ -21,6 +22,6 @@ class ProfileEntity(
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     val user: UserEntity,
 
-    val personalInfo: String? = null,
-    val hostedAccommodations: String? = null
+    @Column(nullable = false)
+    var nickname: String
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileRepository.kt
@@ -1,3 +1,8 @@
 package com.example.toyTeam6Airbnb.profile.persistence
 
-interface ProfileRepository
+import com.example.toyTeam6Airbnb.user.persistence.UserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProfileRepository : JpaRepository<ProfileEntity, Long> {
+    fun findByUser(user: UserEntity): ProfileEntity?
+}

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileService.kt
@@ -1,3 +1,12 @@
 package com.example.toyTeam6Airbnb.profile.service
 
-interface ProfileService
+import com.example.toyTeam6Airbnb.profile.controller.CreateProfileRequest
+import com.example.toyTeam6Airbnb.profile.controller.UpdateProfileRequest
+import com.example.toyTeam6Airbnb.profile.persistence.ProfileEntity
+import com.example.toyTeam6Airbnb.user.persistence.UserEntity
+
+interface ProfileService {
+    fun getCurrentUserProfile(user: UserEntity): ProfileEntity?
+    fun updateCurrentUserProfile(user: UserEntity, request: UpdateProfileRequest): ProfileEntity
+    fun addProfileToCurrentUser(user: UserEntity, request: CreateProfileRequest): ProfileEntity
+}

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
@@ -1,6 +1,38 @@
 package com.example.toyTeam6Airbnb.profile.service
 
+import com.example.toyTeam6Airbnb.profile.controller.CreateProfileRequest
+import com.example.toyTeam6Airbnb.profile.controller.UpdateProfileRequest
+import com.example.toyTeam6Airbnb.profile.persistence.ProfileEntity
+import com.example.toyTeam6Airbnb.profile.persistence.ProfileRepository
+import com.example.toyTeam6Airbnb.user.persistence.UserEntity
+import com.example.toyTeam6Airbnb.user.persistence.UserRepository
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class ProfileServiceImpl : ProfileService
+class ProfileServiceImpl(
+    private val profileRepository: ProfileRepository,
+    private val userRepository: UserRepository
+) : ProfileService {
+
+    override fun getCurrentUserProfile(@AuthenticationPrincipal user: UserEntity): ProfileEntity? {
+        return profileRepository.findByUser(user)
+    }
+
+    @Transactional
+    override fun updateCurrentUserProfile(user: UserEntity, request: UpdateProfileRequest): ProfileEntity {
+        val profile = profileRepository.findByUser(user) ?: throw IllegalArgumentException("Profile not found")
+        profile.nickname = request.nickname
+        return profileRepository.save(profile)
+    }
+
+    @Transactional
+    override fun addProfileToCurrentUser(user: UserEntity, request: CreateProfileRequest): ProfileEntity {
+        if (profileRepository.findByUser(user) != null) {
+            throw IllegalArgumentException("Profile already exists")
+        }
+        val profile = ProfileEntity(user = user, nickname = request.nickname)
+        return profileRepository.save(profile)
+    }
+}


### PR DESCRIPTION
## 📌 Feature Description
User Profile API를 작성하였습니다. Swagger에 추가하였고, 노션 API 컨벤션 문서에도 추가했습니다.

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [x] POST: 현재 로그인된 유저에 대한 Profile 정보 추가. 일반 로그인 유저들은 회원가입 시에 Profile 정보를 받으므로, 이 API는 소셜로그인 유저들에 대해서만 호출되어야 합니다. 성공 시 추가한 Profile DTO를 리턴.
- [x] GET: 현재 로그인된 유저에 대한 Profile 정보 획득. 성공 시 획득한 Profile DTO를 리턴.
- [x] PUT: 현재 로그인된 유저에 대한 Profile 정보 업데이트. 성공 시 업데이트된 Profile DTO를 리턴.

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 한 유저가 다른 유저의 정보를 조회하는 API 구현 필요
- 소셜로그인 유저가 profile 작성하지 않고 다른 페이지로 이동했을 때, error를 리턴해야 함. 해당되는 HTTP status code, error code 및 내용을 정하고, 구현한 후 API 문서에 추가해야 함
- 일반 회원가입 시 profile 내용 받아오도록 API 수정해야 함. -> 이번 스프린트까지는 이를 구현하지 않기로 했으므로 보류!
