### PR TITLE
ReservationService 예약 기간을 포함하는 새로운 예약 예외 처리하도록 수정 + 테스트코드 작성

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -71,7 +71,7 @@ class ReservationServiceImpl(
         // 현재 예약 건을 제외하고, 다른 예약과 겹치는 여부를 확인함.
         // startDate < 기존 예약의 startDate && endDate > 기존 예약의 endDate, 즉 기존 예약을 포괄하는 경우도 제외하도록 조건수정
         return reservations.none { reservation ->
-            reservation.id != currentReservationId && (startDate < reservation.endDate && endDate > reservation.startDate || startDate <= reservation.startDate && endDate >= reservation.endDate)
+            reservation.id != currentReservationId && (startDate < reservation.endDate && endDate > reservation.startDate)
         }
     }
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -69,8 +69,9 @@ class ReservationServiceImpl(
         val reservations = reservationRepository.findAllByRoom(room)
 
         // 현재 예약 건을 제외하고, 다른 예약과 겹치는 여부를 확인함.
+        // startDate < 기존 예약의 startDate && endDate > 기존 예약의 endDate, 즉 기존 예약을 포괄하는 경우도 제외하도록 조건수정
         return reservations.none { reservation ->
-            reservation.id != currentReservationId && startDate < reservation.endDate && endDate > reservation.startDate
+            reservation.id != currentReservationId && (startDate < reservation.endDate && endDate > reservation.startDate || startDate <= reservation.startDate && endDate >= reservation.endDate)
         }
     }
 

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
@@ -1,7 +1,6 @@
 package com.example.toyTeam6Airbnb
 
 import com.example.toyTeam6Airbnb.reservation.persistence.ReservationRepository
-import org.json.JSONObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -11,6 +10,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.LocalDate
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -57,29 +57,10 @@ class ReservationControllerTest {
     fun `특정 ID의 예약 조회 성공시 200 응답 반환`() {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val roomId = room.id
-        val requestBody = """
-            {
-                "roomId": $roomId,
-                "startDate": "2023-12-01",
-                "endDate": "2023-12-10",
-                "numberOfGuests": 2
-            }
-        """.trimIndent()
-
-        val reservation = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
-
-        val reservationId = JSONObject(reservation.response.contentAsString).getLong("id")
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
 
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.get("/api/v1/reservations/$reservationId")
+            MockMvcRequestBuilders.get("/api/v1/reservations/${reservation.id}")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer $token")
         )
@@ -95,30 +76,11 @@ class ReservationControllerTest {
     fun `예약 수정하였을때 응답으로 200이 나와야한다`() {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val roomId = room.id
-        val requestBody = """
-            {
-                "roomId": $roomId,
-                "startDate": "2023-12-01",
-                "endDate": "2023-12-10",
-                "numberOfGuests": 2
-            }
-        """.trimIndent()
-
-        val reservation = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
-
-        val reservationId = JSONObject(reservation.response.contentAsString).getLong("id")
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
 
         val updateRequestBody = """
             {
-                "roomId": $roomId,
+                "roomId": ${room.id},
                 "startDate": "2023-12-01",
                 "endDate": "2024-01-05",
                 "numberOfGuests": 2
@@ -126,7 +88,7 @@ class ReservationControllerTest {
         """.trimIndent()
 
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.put("/api/v1/reservations/$reservationId")
+            MockMvcRequestBuilders.put("/api/v1/reservations/${reservation.id}")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(updateRequestBody)
                 .header("Authorization", "Bearer $token")
@@ -140,38 +102,64 @@ class ReservationControllerTest {
     }
 
     @Test
-    fun `예약을 삭제한 경우 204 응답을 반환한다`() {
-        val (user, token) = dataGenerator.generateUserAndToken()
+    fun `예약 수정은 본인만 가능하다`() {
+        val (user1, token1) = dataGenerator.generateUserAndToken()
+        val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val roomId = room.id
-        val requestBody = """
+        val reservation = dataGenerator.generateReservation(user1, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+
+        // 다른 유저가 예약 수정 시 403 반환
+        val updateRequestBody = """
             {
-                "roomId": $roomId,
+                "roomId": ${room.id},
                 "startDate": "2023-12-01",
-                "endDate": "2023-12-10",
+                "endDate": "2024-01-05",
                 "numberOfGuests": 2
             }
         """.trimIndent()
 
-        val reservation = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/reservations/${reservation.id}")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-                .header("Authorization", "Bearer $token")
+                .content(updateRequestBody)
+                .header("Authorization", "Bearer $token2")
         )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
+            .andExpect(MockMvcResultMatchers.status().isForbidden) // expect 403 status
             .andReturn()
 
-        val reservationId = JSONObject(reservation.response.contentAsString).getLong("id")
+        val responseContent = result.response.contentAsString
+        // Add assertions to verify the response content if needed
+        println(responseContent)
+    }
+
+    @Test
+    fun `예약을 삭제한 경우 204 응답을 반환한다 + 본인만 삭제 가능`() {
+        val (user, token) = dataGenerator.generateUserAndToken()
+        val (user2, token2) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom(maxOccupancy = 10)
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
 
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/v1/reservations/$reservationId")
+            MockMvcRequestBuilders.delete("/api/v1/reservations/${reservation.id}")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
                 .header("Authorization", "Bearer $token")
         )
             .andExpect(MockMvcResultMatchers.status().isNoContent) // expect 204 status
             .andReturn()
+        println(result.response.contentAsString)
+
+        val reservation2 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservationId2 = reservation2.id
+
+        // 다른 유저(user2)가 삭제시 403 반환
+        val result2 = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/v1/reservations/$reservationId2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isForbidden) // expect 403 status
+            .andReturn()
+        println(result2.response.contentAsString)
     }
 
     @Test
@@ -179,41 +167,8 @@ class ReservationControllerTest {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
         val roomId = room.id
-        val requestBody = """
-            {
-                "roomId": $roomId,
-                "startDate": "2023-12-01",
-                "endDate": "2023-12-10",
-                "numberOfGuests": 2
-            }
-        """.trimIndent()
-
-        mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody)
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
-
-        mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                        "roomId": $roomId,
-                        "startDate": "2024-12-01",
-                        "endDate": "2024-12-10",
-                        "numberOfGuests": 2
-                    }
-                    """.trimIndent()
-                )
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
+        dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2024, 12, 1), endDate = LocalDate.of(2024, 12, 10), numberOfGuests = 2)
 
         val result = mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/reservations")
@@ -233,42 +188,8 @@ class ReservationControllerTest {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
         val roomId = room.id
-
-        mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-            {
-                "roomId": $roomId,
-                "startDate": "2025-01-05",
-                "endDate": "2025-01-10",
-                "numberOfGuests": 2
-            }
-                    """.trimIndent()
-                )
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
-
-        mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/v1/reservations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-                    {
-                        "roomId": $roomId,
-                        "startDate": "2025-01-15",
-                        "endDate": "2025-01-20",
-                        "numberOfGuests": 2
-                    }
-                    """.trimIndent()
-                )
-                .header("Authorization", "Bearer $token")
-        )
-            .andExpect(MockMvcResultMatchers.status().isCreated) // expect 201 status
-            .andReturn()
+        val reservation1 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2025, 1, 5), endDate = LocalDate.of(2025, 1, 10), numberOfGuests = 2)
+        val reservation2 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2025, 1, 15), endDate = LocalDate.of(2025, 1, 20), numberOfGuests = 2)
 
         val result = mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/reservations/availability/$roomId")
@@ -283,6 +204,82 @@ class ReservationControllerTest {
         val responseContent = result.response.contentAsString
         // Add assertions to verify the response content if needed
         println(responseContent)
+    }
+
+    // 예약 생성을 2개할때, 중복이 되면 exception 처리가 되는지 확인하는 테스트코드를 작성
+    @Test
+    fun `예약 생성시 기간이 겹치면 409 응답을 반환한다`() {
+        val (user, token) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom(maxOccupancy = 10)
+        val roomId = room.id
+
+        // 1. 날짜가 아예 똑같은 2개
+        val reservation1 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2025, 1, 5), endDate = LocalDate.of(2025, 1, 10), numberOfGuests = 2)
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                        "roomId": $roomId,
+                        "startDate": "2025-01-05",
+                        "endDate": "2025-01-10",
+                        "numberOfGuests": 2
+                    }
+                    """.trimIndent()
+                )
+                .header("Authorization", "Bearer $token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isConflict) // expect 409 status
+            .andReturn()
+
+        // 2. 날짜가 포함되도록 새로운 예약을 만들때
+        val reservation2 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2025, 5, 10), endDate = LocalDate.of(2025, 5, 15), numberOfGuests = 2)
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                        "roomId": $roomId,
+                        "startDate": "2025-05-01",
+                        "endDate": "2025-05-20",
+                        "numberOfGuests": 2
+                    }
+                    """.trimIndent()
+                )
+                .header("Authorization", "Bearer $token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isConflict) // expect 409 status
+            .andReturn()
+
+        val responseContent = result.response.contentAsString
+        // Add assertions to verify the response content if needed
+        println(responseContent)
+    }
+
+    @Test
+    fun `예약 생성시 인원이 0명일 경우 400 응답을 반환한다`() {
+        val (user, token) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom(maxOccupancy = 10)
+        val roomId = room.id
+        val requestBody = """
+        {
+            "roomId": $roomId,
+            "startDate": "2023-12-01",
+            "endDate": "2023-12-10",
+            "numberOfGuests": 0
+        }
+        """.trimIndent()
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+                .header("Authorization", "Bearer $token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest) // expect 400 status
+            .andReturn()
     }
 
     @BeforeEach


### PR DESCRIPTION
## 📌 Feature Description
<!-- 이번 PR에서 추가된 기능의 상세 설명을 작성해주세요. -->
ReservationController Test 테스트케이스 작성과 
그 과정에서 기존 로직에서 코너케이스 발견하여 수정하였습니다.
## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1 : 테스트케이스 구현
1. 새로운 예약 생성시 201 응답 반환
2. 특정 ID의 예약 조회 성공시 200 응답 반환
3. 예약 수정하였을때 응답으로 200이 나와야한다
4. 예약 수정은 본인만 가능하다 (expect 403)
5. 예약을 삭제한 경우 204 응답을 반환한다 + 본인만 삭제 가능 403
6. 전체 예약 조회시 200 응답을 반환한다
7. 예약에대한 Availablity를 200을 반환한다
8. 예약 생성시 기간이 겹치면 409 응답을 반환한다.(날짜가 아예 똑같은 케이스 + 기존 예약날짜를 포함하는 경우)
9. 예약 생성시 인원이 0명일 경우 400 응답을 반환한다

총 9가지 경우에 대해서 구현하였습니다.
`andExpect` 활용하여 에러코드 체크가 필요한 부분을 제외하고는 `dataGenerator`를 최대한 활용하여 가독성을 높이고자 하였으나
구현 케이스가 많다보니 전체 코드길이가 290줄이나 되는.. dirty Code를 만든것 같습니다.
이부분에서 피드백 주시면 감사드립니다 !!


- [ ] 주요 변경사항 2 : 기존 예약기간을 포함하는 경우 available 처리
8번 테스트케이스 구현 과정에서 파악한 코너케이스 입니다.

```
    // 현재 예약 건을 제외하고, 다른 예약과 겹치는 여부를 확인함.
    // startDate < 기존 예약의 startDate && endDate > 기존 예약의 endDate, 즉 기존 예약을 포괄하는 경우도 제외하도록 조건수정
    return reservations.none { reservation ->
        reservation.id != currentReservationId && (startDate < reservation.endDate && endDate > reservation.startDate || startDate <= reservation.startDate && endDate >= reservation.endDate)
    }
}
```
- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
