### PR TITLE
Feat/concurrency reservation

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationRepository.kt
@@ -2,9 +2,17 @@ package com.example.toyTeam6Airbnb.reservation.persistence
 
 import com.example.toyTeam6Airbnb.room.persistence.RoomEntity
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ReservationEntity r WHERE r.id = :id")
+    fun findByIdOrNullForUpdate(id: Long): ReservationEntity?
+
     fun findAllByRoom(room: RoomEntity): List<ReservationEntity>
 
     fun findAllByUser(user: UserEntity): List<ReservationEntity>

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomEntity.kt
@@ -20,12 +20,14 @@ import jakarta.persistence.UniqueConstraint
 import java.time.Instant
 
 @Entity
-@Table(name = "rooms",
+@Table(
+    name = "rooms",
     uniqueConstraints = [
         UniqueConstraint(
             columnNames = ["name", "type", "address"]
         )
-    ])
+    ]
+)
 class RoomEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomEntity.kt
@@ -16,10 +16,16 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import java.time.Instant
 
 @Entity
-@Table(name = "rooms")
+@Table(name = "rooms",
+    uniqueConstraints = [
+        UniqueConstraint(
+            columnNames = ["name", "type", "address"]
+        )
+    ])
 class RoomEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
@@ -14,6 +14,8 @@ interface RoomRepository : JpaRepository<RoomEntity, Long>, JpaSpecificationExec
     fun existsByNameAndTypeAndAddress(name: String, type: RoomType, address: Address): Boolean
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    // query for find by id with lock
+    @Query("SELECT r FROM RoomEntity r WHERE r.id = :id")
     fun findByIdOrNullForUpdate(id: Long): RoomEntity?
 
     @Query(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
@@ -1,15 +1,20 @@
 package com.example.toyTeam6Airbnb.room.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 
 interface RoomRepository : JpaRepository<RoomEntity, Long>, JpaSpecificationExecutor<RoomEntity> {
     fun existsByNameAndTypeAndAddress(name: String, type: RoomType, address: Address): Boolean
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByIdOrNullForUpdate(id: Long): RoomEntity?
 
     @Query(
         """

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomServiceImpl.kt
@@ -92,7 +92,7 @@ class RoomServiceImpl(
         maxOccupancy: Int
     ): Room {
         val hostEntity = userRepository.findByIdOrNull(hostId) ?: throw AuthenticateException()
-        val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
+        val roomEntity = roomRepository.findByIdOrNullForUpdate(roomId) ?: throw RoomNotFoundException()
 
         if (roomEntity.host.id != hostEntity.id) {
             throw RoomPermissionDeniedException()
@@ -123,7 +123,7 @@ class RoomServiceImpl(
         roomId: Long
     ) {
         val hostEntity = userRepository.findByIdOrNull(userId) ?: throw AuthenticateException()
-        val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
+        val roomEntity = roomRepository.findByIdOrNullForUpdate(roomId) ?: throw RoomNotFoundException()
 
         if (roomEntity.host.id != hostEntity.id) throw RoomPermissionDeniedException()
 


### PR DESCRIPTION
## 📌 Feature Description
Reservation service의 동시성 문제 해결
**Room concurrency PR(#72) 먼저 확인해주세요!**

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] Reservation에 변경이 일어나는 경우 pessimistic lock 적용
- [ ] Reservation의 변경으로 인해 다른 reservation들에 영향이 가는 경우 room 자체에 pessimistic lock 적용

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [x] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
