### PR TITLE
Feat/remove redirect auth failure

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/SecurityConfig.kt
@@ -15,6 +15,7 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler
 import org.springframework.web.cors.CorsConfiguration
@@ -95,6 +96,7 @@ class SecurityConfig(
                 usernameParameter = "username"
                 passwordParameter = "password"
                 authenticationSuccessHandler = customAuthenticationSuccessHandler
+                authenticationFailureHandler = SimpleUrlAuthenticationFailureHandler()
             }
             oauth2Login {
                 authorizationEndpoint {
@@ -104,6 +106,7 @@ class SecurityConfig(
                     baseUri = "/api/oauth2/callback/*"
                 }
                 authenticationSuccessHandler = customAuthenticationSuccessHandler
+                authenticationFailureHandler = SimpleUrlAuthenticationFailureHandler()
             }
             logout {
                 logoutUrl = "/api/auth/logout"


### PR DESCRIPTION
## 📌 Feature Description
Authentication failure시에 /login?error로 redirect하는 것이 아니라 http status 401을 리턴하도록 수정하였습니다.

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [x] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
