### PR TITLE
Added review&reservation consent field to profile

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/SecurityConfig.kt
@@ -86,6 +86,7 @@ class SecurityConfig(
                 authorize("/api/oauth2/**", permitAll)
                 authorize(HttpMethod.GET, "/api/v1/rooms/main/**", permitAll)
                 authorize(HttpMethod.GET, "/api/v1/reservations/availability/**", permitAll)
+                authorize(HttpMethod.GET, "/api/v1/reservations/user/**", permitAll)
                 authorize(HttpMethod.GET, "/api/v1/reviews/**", permitAll)
                 authorize("/error", permitAll)
                 authorize("/redirect", permitAll)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/ProfileController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/controller/ProfileController.kt
@@ -53,10 +53,14 @@ class ProfileController(
 
 data class UpdateProfileRequest(
     val nickname: String,
-    val bio: String
+    val bio: String,
+    val showMyReviews: Boolean,
+    val showMyReservations: Boolean
 )
 
 data class CreateProfileRequest(
     val nickname: String,
-    val bio: String
+    val bio: String,
+    val showMyReviews: Boolean,
+    val showMyReservations: Boolean
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/persistence/ProfileEntity.kt
@@ -29,5 +29,11 @@ class ProfileEntity(
     var bio: String,
 
     @Column(nullable = false)
-    var isSuperHost: Boolean = false
+    var isSuperHost: Boolean = false,
+
+    @Column(nullable = false)
+    var showMyReviews: Boolean = false,
+
+    @Column(nullable = false)
+    var showMyReservations: Boolean = false
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
@@ -18,6 +18,7 @@ class ProfileServiceImpl(
     private val roomRepository: RoomRepository
 ) : ProfileService {
 
+    @Transactional
     override fun getCurrentUserProfile(
         user: UserEntity
     ): Profile {
@@ -34,6 +35,8 @@ class ProfileServiceImpl(
 
         profile.nickname = request.nickname
         profile.bio = request.bio
+        profile.showMyReviews = request.showMyReviews
+        profile.showMyReservations = request.showMyReservations
         updateSuperHostStatus(profile)
         profileRepository.save(profile)
 
@@ -50,7 +53,9 @@ class ProfileServiceImpl(
         val profile = ProfileEntity(
             user = user,
             nickname = request.nickname,
-            bio = request.bio
+            bio = request.bio,
+            showMyReviews = request.showMyReviews,
+            showMyReservations = request.showMyReservations
         )
         updateSuperHostStatus(profile)
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/profile/service/ProfileServiceImpl.kt
@@ -31,7 +31,7 @@ class ProfileServiceImpl(
         user: UserEntity,
         request: UpdateProfileRequest
     ): Profile {
-        val profile = profileRepository.findByUser(user) ?: throw ProfileNotFoundException()
+        val profile = profileRepository.findByUser(user) ?: ProfileEntity(user = user, nickname = "", bio = "")
 
         profile.nickname = request.nickname
         profile.bio = request.bio

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
@@ -5,6 +5,7 @@ import com.example.toyTeam6Airbnb.user.controller.PrincipalDetails
 import com.example.toyTeam6Airbnb.user.controller.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -92,8 +93,8 @@ class ReservationController(
     @Operation(summary = "유저별 예약 조회", description = "특정 유저의 모든 예약 정보를 조회합니다")
     fun getReservationsByUser(
         @PathVariable userId: Long,
-        @RequestParam pageable: Pageable
-    ): ResponseEntity<List<ReservationDTO>> {
+        pageable: Pageable
+    ): ResponseEntity<Page<ReservationDTO>> {
         val viewerId =
             try {
                 val principalDetails = SecurityContextHolder.getContext().authentication.principal as PrincipalDetails

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/controller/ReservationController.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -93,7 +94,16 @@ class ReservationController(
         @PathVariable userId: Long,
         @RequestParam pageable: Pageable
     ): ResponseEntity<List<ReservationDTO>> {
-        val reservations = reservationService.getReservationsByUser(userId, pageable)
+        val viewerId =
+            try {
+                val principalDetails = SecurityContextHolder.getContext().authentication.principal as PrincipalDetails
+                principalDetails.getUser().id
+                // logic for when the user is logged in
+            } catch (e: ClassCastException) {
+                // logic for when the user is not logged in
+                null
+            }
+        val reservations = reservationService.getReservationsByUser(viewerId, userId, pageable)
         return ResponseEntity.ok(reservations)
     }
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/persistence/ReservationRepository.kt
@@ -3,6 +3,8 @@ package com.example.toyTeam6Airbnb.reservation.persistence
 import com.example.toyTeam6Airbnb.room.persistence.RoomEntity
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
 import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -15,5 +17,5 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
 
     fun findAllByRoom(room: RoomEntity): List<ReservationEntity>
 
-    fun findAllByUser(user: UserEntity): List<ReservationEntity>
+    fun findAllByUser(user: UserEntity, pageable: Pageable): Page<ReservationEntity>
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
@@ -36,6 +36,7 @@ interface ReservationService {
     ): Reservation
 
     fun getReservationsByUser(
+        viewerId: Long?,
         userId: Long,
         pageable: Pageable
     ): List<ReservationDTO>

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationService.kt
@@ -4,6 +4,7 @@ import com.example.toyTeam6Airbnb.reservation.controller.Reservation
 import com.example.toyTeam6Airbnb.reservation.controller.ReservationDTO
 import com.example.toyTeam6Airbnb.reservation.controller.RoomAvailabilityResponse
 import com.example.toyTeam6Airbnb.user.controller.User
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 import java.time.YearMonth
@@ -39,7 +40,7 @@ interface ReservationService {
         viewerId: Long?,
         userId: Long,
         pageable: Pageable
-    ): List<ReservationDTO>
+    ): Page<ReservationDTO>
 
 //    fun getReservationsByRoom(
 //        roomId: Long

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -132,8 +132,9 @@ class ReservationServiceImpl(
     }
 
     @Transactional
-    override fun getReservationsByUser(userId: Long, pageable: Pageable): List<ReservationDTO> {
+    override fun getReservationsByUser(viewerId: Long?, userId: Long, pageable: Pageable): List<ReservationDTO> {
         val userEntity = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
+        if (viewerId != userId && userEntity.profile?.showMyReservations != true) throw ReservationPermissionDenied()
 
         return reservationRepository.findAllByUser(userEntity).map(ReservationDTO::fromEntity)
     }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -19,6 +19,7 @@ import com.example.toyTeam6Airbnb.user.controller.User
 import com.example.toyTeam6Airbnb.user.persistence.UserRepository
 import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -132,11 +133,11 @@ class ReservationServiceImpl(
     }
 
     @Transactional
-    override fun getReservationsByUser(viewerId: Long?, userId: Long, pageable: Pageable): List<ReservationDTO> {
+    override fun getReservationsByUser(viewerId: Long?, userId: Long, pageable: Pageable): Page<ReservationDTO> {
         val userEntity = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
         if (viewerId != userId && userEntity.profile?.showMyReservations != true) throw ReservationPermissionDenied()
 
-        return reservationRepository.findAllByUser(userEntity).map(ReservationDTO::fromEntity)
+        return reservationRepository.findAllByUser(userEntity, pageable).map(ReservationDTO::fromEntity)
     }
 
 //    @Transactional

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/ReviewController.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -47,7 +47,7 @@ class ReviewController(
     @Operation(summary = "특정 방의 리뷰 조회", description = "특정 방의 모든 리뷰를 조회합니다")
     fun getReviewsByRoom(
         @PathVariable roomId: Long,
-        @RequestParam pageable: Pageable
+        pageable: Pageable
     ): ResponseEntity<Page<ReviewDTO>> {
         val reviews = reviewService.getReviewsByRoom(roomId, pageable)
         return ResponseEntity.ok(reviews)
@@ -66,9 +66,18 @@ class ReviewController(
     @Operation(summary = "특정 유저의 리뷰 조회", description = "특정 유저의 모든 리뷰를 조회합니다")
     fun getReviewsByUser(
         @PathVariable userId: Long,
-        @RequestParam pageable: Pageable
+        pageable: Pageable
     ): ResponseEntity<Page<ReviewDTO>> {
-        val reviews = reviewService.getReviewsByUser(userId, pageable)
+        val viewerId =
+            try {
+                val principalDetails = SecurityContextHolder.getContext().authentication.principal as PrincipalDetails
+                principalDetails.getUser().id
+                // logic for when the user is logged in
+            } catch (e: ClassCastException) {
+                // logic for when the user is not logged in
+                null
+            }
+        val reviews = reviewService.getReviewsByUser(viewerId, userId, pageable)
         return ResponseEntity.ok(reviews)
     }
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/service/ReviewService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/service/ReviewService.kt
@@ -26,6 +26,7 @@ interface ReviewService {
     ): ReviewDTO
 
     fun getReviewsByUser(
+        viewerId: Long?,
         userId: Long,
         pageable: Pageable
     ): Page<ReviewDTO>

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/service/ReviewServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/service/ReviewServiceImpl.kt
@@ -78,8 +78,9 @@ class ReviewServiceImpl(
     }
 
     @Transactional
-    override fun getReviewsByUser(userId: Long, pageable: Pageable): Page<ReviewDTO> {
-        userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
+    override fun getReviewsByUser(viewerId: Long?, userId: Long, pageable: Pageable): Page<ReviewDTO> {
+        val userEntity = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
+        if (viewerId != userId && userEntity.profile?.showMyReviews != true) throw ReviewPermissionDeniedException()
 
         val reviewEntities = reviewRepository.findAllByUserId(userId, validatePageable(pageable))
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
@@ -31,7 +31,7 @@ class UserController(
     fun register(
         @RequestBody request: RegisterRequest
     ): ResponseEntity<Unit> {
-        userService.register(username = request.username, password = request.password)
+        userService.register(request)
         return ResponseEntity.ok().build()
     }
 
@@ -47,5 +47,9 @@ class UserController(
 
 data class RegisterRequest(
     val username: String,
-    val password: String
+    val password: String,
+    val nickname: String,
+    val bio: String,
+    val showMyReviews: Boolean,
+    val showMyReservations: Boolean
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
@@ -1,10 +1,10 @@
 package com.example.toyTeam6Airbnb.user.service
 
+import com.example.toyTeam6Airbnb.user.controller.RegisterRequest
 import com.example.toyTeam6Airbnb.user.controller.User
 
 interface UserService {
     fun register(
-        username: String,
-        password: String
+        request: RegisterRequest
     ): User?
 }

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
@@ -342,8 +342,6 @@ class ReservationControllerTest {
         return if (contentNode.isArray) contentNode.size() else 0
     }
 
-
-
     @BeforeEach
     fun setUp() {
         dataGenerator.clearAll()

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
@@ -297,6 +297,12 @@ class ReservationControllerTest {
             .andExpect(MockMvcResultMatchers.status().isForbidden)
             .andReturn()
 
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
+        )
+            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andReturn()
+
         // update user1's profile
         val updateRequestBody = """
             {
@@ -319,6 +325,12 @@ class ReservationControllerTest {
         mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
                 .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
         )
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn()

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
@@ -1,6 +1,9 @@
 package com.example.toyTeam6Airbnb
 
 import com.example.toyTeam6Airbnb.reservation.persistence.ReservationRepository
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -260,6 +263,86 @@ class ReservationControllerTest {
             .andExpect(MockMvcResultMatchers.status().isBadRequest) // expect 400 status
             .andReturn()
     }
+
+    @Test
+    fun `should get reservations by user`() {
+        val (user, token) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom()
+        val reservation1 = dataGenerator.generateReservation(user, room)
+        val reservation2 = dataGenerator.generateReservation(user, room)
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        println(result)
+        // check result length
+        Assertions.assertEquals(getContentLength(result), 2)
+
+        // check if all reviews are in the result
+        Assertions.assertEquals(getNthContentId(result, 0), reservation1.id)
+        Assertions.assertEquals(getNthContentId(result, 1), reservation2.id)
+
+        // another user should not be able to see the reservations
+        val (user2, token2) = dataGenerator.generateUserAndToken()
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andReturn()
+
+        // update user1's profile
+        val updateRequestBody = """
+            {
+                "nickname": "newNickname",
+                "bio": "newBio",
+                "showMyReviews": true,
+                "showMyReservations": true
+            }
+        """.trimIndent()
+        mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/profile")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestBody)
+                .header("Authorization", "Bearer $token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+
+        // user2 should be able to see the reservations now
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reservations/user/${user.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+    }
+
+    fun getNthContentId(jsonString: String, n: Int): Long? {
+        val objectMapper = ObjectMapper()
+        val rootNode: JsonNode = objectMapper.readTree(jsonString)
+        val contentNode: JsonNode = rootNode.path("content")
+        return if (contentNode.isArray && contentNode.size() > n) {
+            contentNode[n].path("id").asLong()
+        } else {
+            null
+        }
+    }
+
+    fun getContentLength(jsonString: String): Int {
+        val objectMapper = ObjectMapper()
+        val rootNode: JsonNode = objectMapper.readTree(jsonString)
+        val contentNode: JsonNode = rootNode.path("content")
+        return if (contentNode.isArray) contentNode.size() else 0
+    }
+
+
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
@@ -3,6 +3,9 @@ package com.example.toyTeam6Airbnb
 import com.example.toyTeam6Airbnb.review.persistence.ReviewRepository
 import com.example.toyTeam6Airbnb.room.persistence.RoomRepository
 import com.example.toyTeam6Airbnb.user.persistence.UserRepository
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -134,5 +137,87 @@ class ReviewIntegrationTest {
 
         val responseContent = result.response.contentAsString
         println(responseContent)
+    }
+
+    @Test
+    fun `should get reviews by room`() {
+        val (user, token) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom()
+        val reservation1 = dataGenerator.generateReservation(user, room)
+        val reservation2 = dataGenerator.generateReservation(user, room)
+        val review1 = dataGenerator.generateReview(reservation1)
+        val review2 = dataGenerator.generateReview(reservation2)
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/room/${room.id}?page=0&size=3")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        // check result length
+        Assertions.assertEquals(getContentLength(result), 2)
+
+        // check if all reviews are in the result
+        Assertions.assertEquals(getNthContentId(result, 0), review1.id)
+        Assertions.assertEquals(getNthContentId(result, 1), review2.id)
+        println(result)
+    }
+
+    fun getNthContentId(jsonString: String, n: Int): Long? {
+        val objectMapper = ObjectMapper()
+        val rootNode: JsonNode = objectMapper.readTree(jsonString)
+        val contentNode: JsonNode = rootNode.path("content")
+        return if (contentNode.isArray && contentNode.size() > n) {
+            contentNode[n].path("id").asLong()
+        } else {
+            null
+        }
+    }
+
+    fun getContentLength(jsonString: String): Int {
+        val objectMapper = ObjectMapper()
+        val rootNode: JsonNode = objectMapper.readTree(jsonString)
+        val contentNode: JsonNode = rootNode.path("content")
+        return if (contentNode.isArray) contentNode.size() else 0
+    }
+
+    @Test
+    fun `should get reviews by user`() {
+        val (user1, token1) = dataGenerator.generateUserAndToken()
+        val room = dataGenerator.generateRoom()
+        val reservation1 = dataGenerator.generateReservation(user1, room)
+        val reservation2 = dataGenerator.generateReservation(user1, room)
+        val review1 = dataGenerator.generateReview(reservation1)
+        val review2 = dataGenerator.generateReview(reservation2)
+
+        // the owning user should be able to see all reviews
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token1")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        // check result length
+        Assertions.assertEquals(getContentLength(result), 2)
+
+        // check if all reviews are in the result
+        Assertions.assertEquals(getNthContentId(result, 0), review1.id)
+        Assertions.assertEquals(getNthContentId(result, 1), review2.id)
+        println(result)
+
+        // another user should not be able to see the reviews
+        val (user2, token2) = dataGenerator.generateUserAndToken()
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andReturn()
     }
 }

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
@@ -219,5 +219,31 @@ class ReviewIntegrationTest {
         )
             .andExpect(MockMvcResultMatchers.status().isForbidden)
             .andReturn()
+
+        // update user1's profile
+        val updateRequestBody = """
+            {
+                "nickname": "newNickname",
+                "bio": "newBio",
+                "showMyReviews": true,
+                "showMyReservations": true
+            }
+        """.trimIndent()
+        mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/profile")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestBody)
+                .header("Authorization", "Bearer $token1")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+
+        // user2 should be able to see the reviews now
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
+                .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
     }
 }

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReviewIntegrationTest.kt
@@ -220,6 +220,12 @@ class ReviewIntegrationTest {
             .andExpect(MockMvcResultMatchers.status().isForbidden)
             .andReturn()
 
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
+        )
+            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andReturn()
+
         // update user1's profile
         val updateRequestBody = """
             {
@@ -242,6 +248,12 @@ class ReviewIntegrationTest {
         mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
                 .header("Authorization", "Bearer $token2")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/reviews/user/${user1.id}?page=0&size=3")
         )
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn()

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/UserControllerTest.kt
@@ -30,7 +30,11 @@ constructor(
         val requestBody = """
             {
                 "username": "testuser",
-                "password": "password123"
+                "password": "password123",
+                "nickname": "testuser",
+                "bio": "Hello, I'm a test user!",
+                "showMyReviews": true,
+                "showMyReservations": true
             }
         """.trimIndent()
 


### PR DESCRIPTION
## 📌 Feature Description
Profile에 리뷰 및 예약 타인 공개 설정에 대한 필드를 추가하였습니다.

## 🔧 Implementation Details
- [x] showMyReviews, showMyReservations 필드 추가
- [x] showMyXXX 설정이 되어 있을 때만 타 유저 및 미로그인 유저에게 리뷰/예약이 보이도록 설정
- [x] Reservation-by-user, review-by-user, review-by-room의 pageable 파라미터 오류 수정(annotation 제거)
- [x] reservation-by-user 리턴 타입 page로 수정
- [x] Reservation-by-user, review-by-user, review-by-room 정상동작 확인 위의 필드들 정상 동작하는지 확인하는 테스트 추가

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [x] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->