### PR TITLE
Fixed swagger login endpoint error & added complete-profile field to …

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
@@ -2,6 +2,7 @@ package com.example.toyTeam6Airbnb.config
 
 import com.example.toyTeam6Airbnb.user.JwtTokenProvider
 import com.example.toyTeam6Airbnb.user.controller.PrincipalDetails
+import com.example.toyTeam6Airbnb.user.persistence.AuthProvider
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
@@ -23,6 +24,8 @@ class CustomAuthenticationSuccessHandler(
     ) {
         val token = jwtTokenProvider.generateToken(authentication.name)
 
-        response.sendRedirect("/redirect?token=$token&userid=${(authentication.principal as PrincipalDetails).getId()}")
+        val principal = authentication.principal as PrincipalDetails
+
+        response.sendRedirect("/redirect?token=$token&userid=${principal.getId()}&complete-profile=${principal.getUser().provider != AuthProvider.LOCAL}")
     }
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
@@ -3,6 +3,7 @@ package com.example.toyTeam6Airbnb.user.controller
 import com.example.toyTeam6Airbnb.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -37,6 +38,14 @@ class UserController(
         return ResponseEntity.ok(UrlResponse(url))
     }
 
+    @PostMapping("/api/auth/login", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    @Operation(summary = "로그인", description = "유저 로그인")
+    fun fakeLogin(
+        @RequestBody request: LoginRequest
+    ): ResponseEntity<String> {
+        return ResponseEntity.ok("Fake endpoint to bypass Swagger login endpoint bug. This method shouldn't be called. It must be shadowed by Spring Security login endpoint.")
+    }
+
     // a mapping just for swagger testing
     // token parameter is passed as a query parameter
     // just return the token parameter in body
@@ -46,6 +55,11 @@ class UserController(
         return ResponseEntity.ok(RedirectResponse(token, userid))
     }
 }
+
+data class LoginRequest(
+    val username: String,
+    val password: String
+)
 
 data class RegisterRequest(
     val username: String,
@@ -62,5 +76,5 @@ data class RedirectResponse(
 )
 
 data class UrlResponse(
-    val imageUploadurl: String
+    val imageUploadUrl: String
 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,4 +65,3 @@ springdoc:
     oauth2RedirectUrl: '/api/oauth2/callback/google'
     oauth:
       use-pkce-with-authorization-code-grant: true
-  show-login-endpoint: true


### PR DESCRIPTION
…login redirect

## 📌 Feature Description
- Swagger login endpoint에 기능에 버그가 있었습니다. 인증 오류 핸들러를 추가하면 login endpoint의 형식이 x-www-form-urlencoded에서 json으로 바뀌어 버립니다. 해결을 위해 swagger 자체의 login endpoint 기능을 해제하고 User controller에 dummy endpoint를 생성하였습니다.
- 방금 로그인한 유저가 profile 정보 추가가 필요할 경우 redirect url의 get parameter에 complete-profile=true가 들어가도록 수정했습니다.

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1
- [ ] 주요 변경사항 2
- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [x] 코드가 컴파일되고 정상적으로 동작
- [x] 모든 테스트 통과
- [x] Linter 돌리기
- [x] 관련 작업 kanban update
- [x] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
