### PR TITLE
Block reservation to past date

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/reservation/service/ReservationServiceImpl.kt
@@ -79,6 +79,7 @@ class ReservationServiceImpl(
 
     fun isAvailable(room: RoomEntity, startDate: LocalDate, endDate: LocalDate, currentReservationId: Long? = null): Boolean {
         // exception 발생도 함께 처리
+        if (startDate <= LocalDate.now()) throw ReservationUnavailable()
         if (startDate >= endDate) throw ReservationUnavailable()
         val reservations = reservationRepository.findAllByRoom(room)
 

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationControllerTest.kt
@@ -36,8 +36,8 @@ class ReservationControllerTest {
         val requestBody = """
             {
                 "roomId": $roomId,
-                "startDate": "2023-12-01",
-                "endDate": "2023-12-10",
+                "startDate": "2026-12-01",
+                "endDate": "2026-12-10",
                 "numberOfGuests": 2
             }
         """.trimIndent()
@@ -60,7 +60,7 @@ class ReservationControllerTest {
     fun `특정 ID의 예약 조회 성공시 200 응답 반환`() {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2026, 12, 1), endDate = LocalDate.of(2026, 12, 10), numberOfGuests = 2)
 
         val result = mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/reservations/${reservation.id}")
@@ -79,12 +79,12 @@ class ReservationControllerTest {
     fun `예약 수정하였을때 응답으로 200이 나와야한다`() {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2026, 12, 1), endDate = LocalDate.of(2026, 12, 10), numberOfGuests = 2)
 
         val updateRequestBody = """
             {
-                "startDate": "2023-12-01",
-                "endDate": "2024-01-05",
+                "startDate": "2026-12-01",
+                "endDate": "2027-01-05",
                 "numberOfGuests": 2
             }
         """.trimIndent()
@@ -108,12 +108,12 @@ class ReservationControllerTest {
         val (user1, token1) = dataGenerator.generateUserAndToken()
         val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val reservation = dataGenerator.generateReservation(user1, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservation = dataGenerator.generateReservation(user1, room, startDate = LocalDate.of(2026, 12, 1), endDate = LocalDate.of(2026, 12, 10), numberOfGuests = 2)
 
         // 다른 유저가 예약 수정 시 403 반환
         val updateRequestBody = """
             {
-                "startDate": "2023-12-01",
+                "startDate": "2026-12-01",
                 "endDate": "2024-01-05",
                 "numberOfGuests": 2
             }
@@ -138,7 +138,7 @@ class ReservationControllerTest {
         val (user, token) = dataGenerator.generateUserAndToken()
         val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 10)
-        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservation = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2026, 12, 1), endDate = LocalDate.of(2026, 12, 10), numberOfGuests = 2)
 
         val result = mockMvc.perform(
             MockMvcRequestBuilders.delete("/api/v1/reservations/${reservation.id}")
@@ -149,7 +149,7 @@ class ReservationControllerTest {
             .andReturn()
         println(result.response.contentAsString)
 
-        val reservation2 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2023, 12, 1), endDate = LocalDate.of(2023, 12, 10), numberOfGuests = 2)
+        val reservation2 = dataGenerator.generateReservation(user, room, startDate = LocalDate.of(2026, 12, 1), endDate = LocalDate.of(2026, 12, 10), numberOfGuests = 2)
         val reservationId2 = reservation2.id
 
         // 다른 유저(user2)가 삭제시 403 반환
@@ -245,8 +245,8 @@ class ReservationControllerTest {
         val requestBody = """
         {
             "roomId": $roomId,
-            "startDate": "2023-12-01",
-            "endDate": "2023-12-10",
+            "startDate": "2026-12-01",
+            "endDate": "2026-12-10",
             "numberOfGuests": 0
         }
         """.trimIndent()

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationIntegrationTest.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/ReservationIntegrationTest.kt
@@ -50,8 +50,8 @@ class ReservationIntegrationTest {
         val (user, token) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 2)
 
-        val startDate = LocalDate.of(2023, 12, 1)
-        val endDate = LocalDate.of(2023, 12, 10)
+        val startDate = LocalDate.of(2026, 12, 1)
+        val endDate = LocalDate.of(2026, 12, 10)
 
         val latch = CountDownLatch(2)
         val executor = Executors.newFixedThreadPool(2)
@@ -109,8 +109,8 @@ class ReservationIntegrationTest {
         val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 2)
 
-        val startDate = LocalDate.of(2023, 12, 1)
-        val endDate = LocalDate.of(2023, 12, 10)
+        val startDate = LocalDate.of(2026, 12, 1)
+        val endDate = LocalDate.of(2026, 12, 10)
 
         val latch = CountDownLatch(2)
         val executor = Executors.newFixedThreadPool(2)
@@ -168,10 +168,10 @@ class ReservationIntegrationTest {
         val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 2)
 
-        val startDate1 = LocalDate.of(2023, 12, 1)
-        val endDate1 = LocalDate.of(2023, 12, 5)
-        val startDate2 = LocalDate.of(2023, 12, 6)
-        val endDate2 = LocalDate.of(2023, 12, 10)
+        val startDate1 = LocalDate.of(2026, 12, 1)
+        val endDate1 = LocalDate.of(2026, 12, 5)
+        val startDate2 = LocalDate.of(2026, 12, 6)
+        val endDate2 = LocalDate.of(2026, 12, 10)
 
         val latch = CountDownLatch(2)
         val executor = Executors.newFixedThreadPool(2)
@@ -238,10 +238,10 @@ class ReservationIntegrationTest {
         val (user2, token2) = dataGenerator.generateUserAndToken()
         val room = dataGenerator.generateRoom(maxOccupancy = 2)
 
-        val startDate1 = LocalDate.of(2023, 5, 10)
-        val endDate1 = LocalDate.of(2023, 5, 15)
-        val startDate2 = LocalDate.of(2023, 5, 12)
-        val endDate2 = LocalDate.of(2023, 5, 17)
+        val startDate1 = LocalDate.of(2026, 5, 10)
+        val endDate1 = LocalDate.of(2026, 5, 15)
+        val startDate2 = LocalDate.of(2026, 5, 12)
+        val endDate2 = LocalDate.of(2026, 5, 17)
 
         val latch = CountDownLatch(2)
         val executor = Executors.newFixedThreadPool(2)


### PR DESCRIPTION
# NOTE: DO NOT MERGE
리뷰 작성을 위해서는 과거 예약이 필요하기 때문에 해당 PR의 머지를 보류해야 할 것 같습니다.
## 📌 Feature Description
과거 날짜에 대한 예약의 경우 `ReservationUnavailable`을 `throw`하도록 구현하였습니다.

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1
- [ ] 주요 변경사항 2
- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
