### PR TITLE
Implement JWT Token refresh

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/config/CustomAuthenticationSuccessHandler.kt
@@ -32,6 +32,6 @@ class CustomAuthenticationSuccessHandler(
 
         val principal = authentication.principal as PrincipalDetails
 
-        response.sendRedirect("/redirect?token=$token&userid=${principal.getId()}&complete-profile=${!userService.hasProfile(authentication.name)}")
+        response.sendRedirect("/redirect?token=${token.accessToken}&refreshToken=${token.refreshToken}&userid=${principal.getId()}&complete-profile=${!userService.hasProfile(authentication.name)}")
     }
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/JwtTokenProvider.kt
@@ -1,8 +1,12 @@
 package com.example.toyTeam6Airbnb.user
 
+import com.example.toyTeam6Airbnb.user.persistence.RefreshTokenEntity
+import com.example.toyTeam6Airbnb.user.persistence.RefreshTokenRepository
+import com.example.toyTeam6Airbnb.user.persistence.UserRepository
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
+import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.util.Date
@@ -10,32 +14,46 @@ import java.util.Date
 @Component
 class JwtTokenProvider(
     @Value("\${spring.security.jwt-secret}")
-    private val jwtSecret: String // Move to configuration
+    private val jwtSecret: String, // Move to configuration
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val userRepository: UserRepository
 ) {
-    private val jwtExpirationMs: Long = 86400000L // 24 hours
+    private val jwtExpirationMs: Long = 3600000L // 1 hour
+    private val jwtRefreshExpirationMs: Long = 86400000L // 24 hours
 
-    fun generateToken(username: String): String {
+    @Transactional
+    fun generateToken(username: String): TokenDto {
         val now = Date()
-        val expiryDate = Date(now.time + jwtExpirationMs)
-
-        return Jwts.builder()
+        val accessToken = Jwts.builder()
             .setSubject(username)
             .setIssuedAt(now)
-            .setExpiration(expiryDate)
+            .setExpiration(Date(now.time + jwtExpirationMs))
             .signWith(Keys.hmacShaKeyFor(jwtSecret.toByteArray()), SignatureAlgorithm.HS512)
             .compact()
+        val refreshToken = Jwts.builder()
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(Date(now.time + jwtRefreshExpirationMs))
+            .signWith(Keys.hmacShaKeyFor(jwtSecret.toByteArray()), SignatureAlgorithm.HS512)
+            .compact()
+
+        val userEntity = userRepository.findByUsername(username)!!
+        refreshTokenRepository.deleteByUser(userEntity)
+        refreshTokenRepository.flush()
+        refreshTokenRepository.save(RefreshTokenEntity(token = refreshToken, user = userEntity))
+
+        return TokenDto(
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
     }
 
     fun validateToken(token: String): Boolean {
-        try {
-            Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(jwtSecret.toByteArray()))
-                .build()
-                .parseClaimsJws(token)
-            return true
-        } catch (ex: Exception) {
-            return false
-        }
+        Jwts.parserBuilder()
+            .setSigningKey(Keys.hmacShaKeyFor(jwtSecret.toByteArray()))
+            .build()
+            .parseClaimsJws(token)
+        return true
     }
 
     fun getUsernameFromToken(token: String): String {
@@ -47,3 +65,8 @@ class JwtTokenProvider(
         return claims.subject
     }
 }
+
+data class TokenDto(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/UserException.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/UserException.kt
@@ -67,14 +67,20 @@ class UserWithNoProfileException : UserException(
     msg = "User with no profile"
 )
 
-class JWTException : UserException(
+class JWTUnknownException : UserException(
     errorCode = 1010,
     httpStatusCode = HttpStatus.UNAUTHORIZED,
-    msg = "JWT Token error"
+    msg = "Unknown JWT Token error"
 )
 
-class likedRoomsPermissionDenied : UserException(
+class LikedRoomsPermissionDenied : UserException(
     errorCode = 1011,
     httpStatusCode = HttpStatus.FORBIDDEN,
     msg = "Permission Denied"
+)
+
+class JwtExpiredException : UserException(
+    errorCode = 1012,
+    httpStatusCode = HttpStatus.UNAUTHORIZED,
+    msg = "JWT Token expired"
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.example.toyTeam6Airbnb.user.controller
 
 import com.example.toyTeam6Airbnb.room.controller.Room
+import com.example.toyTeam6Airbnb.user.JwtTokenProvider
 import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
@@ -19,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @Tag(name = "User Controller", description = "User Controller API")
 class UserController(
-    private val userService: UserService
+    private val userService: UserService,
+    private val jwtTokenProvider: JwtTokenProvider
 ) {
 
     @PostMapping("/api/v1/ping")
@@ -56,7 +58,7 @@ class UserController(
     fun refreshToken(
         @RequestParam refreshToken: String
     ): ResponseEntity<TokenDto> {
-        return ResponseEntity.ok(userService.reissueToken(refreshToken))
+        return ResponseEntity.ok(jwtTokenProvider.reissueToken(refreshToken))
     }
 
     // a mapping just for swagger testing

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.example.toyTeam6Airbnb.user.controller
 
 import com.example.toyTeam6Airbnb.room.controller.Room
+import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -50,13 +51,25 @@ class UserController(
         return ResponseEntity.ok("Fake endpoint to bypass Swagger login endpoint bug. This method shouldn't be called. It must be shadowed by Spring Security login endpoint.")
     }
 
+    @PostMapping("/api/auth/reissueToken")
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 엑세스 토큰 재발급")
+    fun refreshToken(
+        @RequestParam refreshToken: String
+    ): ResponseEntity<TokenDto> {
+        return ResponseEntity.ok(userService.reissueToken(refreshToken))
+    }
+
     // a mapping just for swagger testing
     // token parameter is passed as a query parameter
     // just return the token parameter in body
     @Operation(summary = "Redirect", description = "Redirect to the token", hidden = true)
     @GetMapping("/redirect")
-    fun redirect(@RequestParam token: String, @RequestParam userid: Long): ResponseEntity<RedirectResponse> {
-        return ResponseEntity.ok(RedirectResponse(token, userid))
+    fun redirect(
+        @RequestParam token: String,
+        @RequestParam refreshToken: String,
+        @RequestParam userid: Long
+    ): ResponseEntity<RedirectResponse> {
+        return ResponseEntity.ok(RedirectResponse(token, refreshToken, userid))
     }
 
     @GetMapping("/api/v1/users/{userId}/liked-rooms")
@@ -96,6 +109,7 @@ data class RegisterRequest(
 
 data class RedirectResponse(
     val token: String,
+    val refreshToken: String,
     val userId: Long
 )
 

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
@@ -1,0 +1,24 @@
+package com.example.toyTeam6Airbnb.user.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+
+@Entity(name = "refresh_tokens")
+class RefreshTokenEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(nullable = false)
+    var token: String,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    var user: UserEntity
+)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
@@ -19,6 +19,6 @@ class RefreshTokenEntity(
     var token: String,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false)
     var user: UserEntity
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenEntity.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
+import jakarta.persistence.ManyToOne
 
 @Entity(name = "refresh_tokens")
 class RefreshTokenEntity(
@@ -18,7 +18,7 @@ class RefreshTokenEntity(
     @Column(nullable = false)
     var token: String,
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     var user: UserEntity
 )

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/RefreshTokenRepository.kt
@@ -1,0 +1,9 @@
+package com.example.toyTeam6Airbnb.user.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<RefreshTokenEntity, Long> {
+    fun findByToken(token: String): RefreshTokenEntity?
+    fun deleteByToken(token: String)
+    fun deleteByUser(user: UserEntity)
+}

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/persistence/UserEntity.kt
@@ -51,6 +51,9 @@ class UserEntity(
     @OneToOne(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
     var profile: ProfileEntity? = null,
 
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY, orphanRemoval = true)
+    var refreshTokens: MutableList<RefreshTokenEntity> = mutableListOf(),
+
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE], orphanRemoval = true)
     var roomLikes: MutableList<RoomLikeEntity> = mutableListOf()
 ) {

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
@@ -1,7 +1,6 @@
 package com.example.toyTeam6Airbnb.user.service
 
 import com.example.toyTeam6Airbnb.room.controller.Room
-import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.controller.RegisterRequest
 import com.example.toyTeam6Airbnb.user.controller.User
 import org.springframework.data.domain.Page
@@ -16,10 +15,6 @@ interface UserService {
     fun hasProfile(
         username: String
     ): Boolean
-
-    fun reissueToken(
-        refreshToken: String
-    ): TokenDto
 
     // 사용자가 좋아요 누른 방 리스트 조회
     fun getLikedRooms(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.example.toyTeam6Airbnb.user.service
 
 import com.example.toyTeam6Airbnb.room.controller.Room
+import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.controller.RegisterRequest
 import com.example.toyTeam6Airbnb.user.controller.User
 import org.springframework.data.domain.Page
@@ -15,6 +16,10 @@ interface UserService {
     fun hasProfile(
         username: String
     ): Boolean
+
+    fun reissueToken(
+        refreshToken: String
+    ): TokenDto
 
     // 사용자가 좋아요 누른 방 리스트 조회
     fun getLikedRooms(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserServiceImpl.kt
@@ -5,16 +5,22 @@ import com.example.toyTeam6Airbnb.profile.persistence.ProfileEntity
 import com.example.toyTeam6Airbnb.profile.persistence.ProfileRepository
 import com.example.toyTeam6Airbnb.room.controller.Room
 import com.example.toyTeam6Airbnb.room.persistence.RoomLikeRepository
+import com.example.toyTeam6Airbnb.user.JWTUnknownException
+import com.example.toyTeam6Airbnb.user.JwtExpiredException
+import com.example.toyTeam6Airbnb.user.JwtTokenProvider
+import com.example.toyTeam6Airbnb.user.LikedRoomsPermissionDenied
 import com.example.toyTeam6Airbnb.user.SignUpBadUsernameException
 import com.example.toyTeam6Airbnb.user.SignUpUsernameConflictException
+import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.UserNotFoundException
 import com.example.toyTeam6Airbnb.user.controller.RegisterRequest
 import com.example.toyTeam6Airbnb.user.controller.User
-import com.example.toyTeam6Airbnb.user.likedRoomsPermissionDenied
 import com.example.toyTeam6Airbnb.user.persistence.AuthProvider
+import com.example.toyTeam6Airbnb.user.persistence.RefreshTokenRepository
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
 import com.example.toyTeam6Airbnb.user.persistence.UserRepository
 import com.example.toyTeam6Airbnb.validateSortedPageable
+import io.jsonwebtoken.ExpiredJwtException
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -28,7 +34,9 @@ class UserServiceImpl(
     private val profileRepository: ProfileRepository,
     private val imageService: ImageService,
     private val passwordEncoder: PasswordEncoder,
-    private val roomLikeRepository: RoomLikeRepository
+    private val roomLikeRepository: RoomLikeRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider
 ) : UserService {
     @Transactional
     override fun register(
@@ -63,6 +71,23 @@ class UserServiceImpl(
         return true
     }
 
+    override fun reissueToken(
+        refreshToken: String
+    ): TokenDto {
+        try {
+            val username = jwtTokenProvider.getUsernameFromToken(refreshToken)
+            refreshTokenRepository.findByToken(refreshToken) ?: throw JWTUnknownException()
+            val tokens = jwtTokenProvider.generateToken(username)
+            return tokens
+        } catch (e: Exception) {
+            if (e is ExpiredJwtException) {
+                throw JwtExpiredException()
+            } else {
+                throw JWTUnknownException()
+            }
+        }
+    }
+
     @Transactional
     override fun getLikedRooms(
         viewerId: Long?,
@@ -70,7 +95,7 @@ class UserServiceImpl(
         pageable: Pageable
     ): Page<Room> {
         val userEntity = userRepository.findByIdOrNull(userId) ?: throw UserNotFoundException()
-        if (viewerId != userId && userEntity.profile?.showMyWishlist != true) throw likedRoomsPermissionDenied()
+        if (viewerId != userId && userEntity.profile?.showMyWishlist != true) throw LikedRoomsPermissionDenied()
         // 요청을 보낸 사용자가 본인이 아니고, 위시리스트 공개를 안한 경우에는 Permission Denied
         return roomLikeRepository.findRoomsLikedByUser(userEntity, validateSortedPageable(pageable)).map { roomEntity ->
             val imageUrl = imageService.generateRoomImageDownloadUrl(roomEntity.id!!)

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/user/service/UserServiceImpl.kt
@@ -5,13 +5,10 @@ import com.example.toyTeam6Airbnb.profile.persistence.ProfileEntity
 import com.example.toyTeam6Airbnb.profile.persistence.ProfileRepository
 import com.example.toyTeam6Airbnb.room.controller.Room
 import com.example.toyTeam6Airbnb.room.persistence.RoomLikeRepository
-import com.example.toyTeam6Airbnb.user.JWTUnknownException
-import com.example.toyTeam6Airbnb.user.JwtExpiredException
 import com.example.toyTeam6Airbnb.user.JwtTokenProvider
 import com.example.toyTeam6Airbnb.user.LikedRoomsPermissionDenied
 import com.example.toyTeam6Airbnb.user.SignUpBadUsernameException
 import com.example.toyTeam6Airbnb.user.SignUpUsernameConflictException
-import com.example.toyTeam6Airbnb.user.TokenDto
 import com.example.toyTeam6Airbnb.user.UserNotFoundException
 import com.example.toyTeam6Airbnb.user.controller.RegisterRequest
 import com.example.toyTeam6Airbnb.user.controller.User
@@ -20,7 +17,6 @@ import com.example.toyTeam6Airbnb.user.persistence.RefreshTokenRepository
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
 import com.example.toyTeam6Airbnb.user.persistence.UserRepository
 import com.example.toyTeam6Airbnb.validateSortedPageable
-import io.jsonwebtoken.ExpiredJwtException
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -69,23 +65,6 @@ class UserServiceImpl(
     ): Boolean {
         userRepository.findByUsername(username)?.profile ?: return false
         return true
-    }
-
-    override fun reissueToken(
-        refreshToken: String
-    ): TokenDto {
-        try {
-            val username = jwtTokenProvider.getUsernameFromToken(refreshToken)
-            refreshTokenRepository.findByToken(refreshToken) ?: throw JWTUnknownException()
-            val tokens = jwtTokenProvider.generateToken(username)
-            return tokens
-        } catch (e: Exception) {
-            if (e is ExpiredJwtException) {
-                throw JwtExpiredException()
-            } else {
-                throw JWTUnknownException()
-            }
-        }
     }
 
     @Transactional

--- a/src/test/kotlin/com/example/toyTeam6Airbnb/DataGenerator.kt
+++ b/src/test/kotlin/com/example/toyTeam6Airbnb/DataGenerator.kt
@@ -77,7 +77,7 @@ class DataGenerator(
         val profile = generateProfile(userEntity)
         userEntity.profile = profile
 
-        return userEntity to jwtTokenProvider.generateToken(userEntity.username)
+        return userEntity to jwtTokenProvider.generateToken(userEntity.username).accessToken
     }
 
     fun generateReview(


### PR DESCRIPTION
## 📌 Feature Description
JWT token refresh 구현하였습니다. 이제 로그인 시 발급되는 JWT 토큰의 유효기간은 1시간으로 제한되며, 만료된 토큰으로 API 접근할 시

- HTTP UNAUTHORIZED
-  error: "JWT Token expired"
- errorCode: 1012

가 반환됩니다.만료 시 재발급을 위해 로그인 직후에 token과 함께 refreshToken이 발급됩니다(`/redirect` 파라미터에 추가됨). 토큰이 만료되면 미리 저장해 두었던 refreshToken을 담아 `/api/auth/reissueToken`에 요청을 보내서 재발급받으시면 됩니다. 이때 일반 token뿐만 아니라 refresh token까지 새로 발급되므로 유의해 주세요.

+) refreshToken 자체의 유효기간도 존재하므로(24시간), reissueToken에서도 JWT Token expired 에러가 발생할 수 있습니다.

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- [ ] 주요 변경사항 1
- [ ] 주요 변경사항 2
- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
