### PR TITLE
유저가 작성한 리뷰 조회시 필드 추가 / 유저가 생성한 숙소 리스트 제공 API 생성

### DIFF
--- a/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/Review.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/review/controller/Review.kt
@@ -29,7 +29,9 @@ data class ReviewByRoomDTO(
 }
 
 data class ReviewByUserDTO(
+    val reviewId: Long, // 리뷰 id
     val reservationId: Long,
+    val roomId: Long, // 숙소 id
     val content: String,
     val rating: Int,
     val place: String,
@@ -40,7 +42,9 @@ data class ReviewByUserDTO(
     companion object {
         fun fromEntity(entity: ReviewEntity, imageUrl: String): ReviewByUserDTO {
             return ReviewByUserDTO(
+                reviewId = entity.id!!,
                 reservationId = entity.reservation.id!!,
+                roomId = entity.room.id!!,
                 content = entity.content,
                 rating = entity.rating,
                 place = entity.room.address.sido,

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/Room.kt
@@ -88,3 +88,33 @@ data class RoomShortDTO(
         }
     }
 }
+
+// 호스트가 생성한 숙소들 목록을 제공하기 위해 만듬
+// 숙소 수정/삭제를 위해서 제공
+data class RoomByUserDTO(
+    val roomId: Long,
+    val roomName: String,
+    val description: String,
+    val address: Address,
+    val roomType: RoomType,
+    val roomDetails: RoomDetails,
+    val price: Price,
+    val maxOccupancy: Int,
+    val imageUrl: String
+) {
+    companion object {
+        fun fromEntity(entity: RoomEntity, imageUrl: String): RoomByUserDTO {
+            return RoomByUserDTO(
+                roomId = entity.id!!,
+                roomName = entity.name,
+                description = entity.description,
+                roomType = entity.type,
+                address = entity.address,
+                roomDetails = entity.roomDetails,
+                price = entity.price,
+                maxOccupancy = entity.maxOccupancy,
+                imageUrl = imageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/RoomController.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/controller/RoomController.kt
@@ -70,6 +70,16 @@ class RoomController(
         return ResponseEntity.ok(room)
     }
 
+    @GetMapping("/rooms/{hostId}")
+    @Operation(summary = "호스트 방 조회", description = "특정 호스트의 방 목록을 조회합니다(페이지네이션 적용), 대표이미지 조회 URL 제공")
+    fun getRoomsByHostId(
+        @PathVariable hostId: Long,
+        pageable: Pageable
+    ): ResponseEntity<Page<RoomByUserDTO>> {
+        val rooms = roomService.getRoomsByHostId(hostId, pageable)
+        return ResponseEntity.ok(rooms)
+    }
+
     @PutMapping("/rooms/{roomId}")
     @Operation(summary = "방 정보 수정", description = "방의 정보를 수정합니다, 이미지 업로드 URL 제공")
     fun updateRoom(

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/persistence/RoomRepository.kt
@@ -2,6 +2,8 @@ package com.example.toyTeam6Airbnb.room.persistence
 
 import com.example.toyTeam6Airbnb.user.persistence.UserEntity
 import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Lock
@@ -16,4 +18,8 @@ interface RoomRepository : JpaRepository<RoomEntity, Long>, JpaSpecificationExec
     fun findByIdOrNullForUpdate(id: Long): RoomEntity?
 
     fun countByHost(userEntity: UserEntity): Int
+
+    // query for find by host
+    @Query("SELECT r FROM RoomEntity r WHERE r.host = :host")
+    fun findAllByHostId(hostId: Long, pageable: Pageable): Page<RoomEntity>
 }

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomService.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomService.kt
@@ -2,6 +2,7 @@ package com.example.toyTeam6Airbnb.room.service
 
 import com.example.toyTeam6Airbnb.room.controller.AddressSearchDTO
 import com.example.toyTeam6Airbnb.room.controller.Room
+import com.example.toyTeam6Airbnb.room.controller.RoomByUserDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomDetailSearchDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomDetailsDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomShortDTO
@@ -29,6 +30,8 @@ interface RoomService {
     fun getRooms(pageable: Pageable): Page<Room>
 
     fun getRoomDetails(roomId: Long): RoomDetailsDTO
+
+    fun getRoomsByHostId(hostId: Long, pageable: Pageable): Page<RoomByUserDTO>
 
     fun updateRoom(
         hostId: Long,

--- a/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomServiceImpl.kt
+++ b/src/main/kotlin/com/example/toyTeam6Airbnb/room/service/RoomServiceImpl.kt
@@ -14,6 +14,7 @@ import com.example.toyTeam6Airbnb.room.RoomNotFoundException
 import com.example.toyTeam6Airbnb.room.RoomPermissionDeniedException
 import com.example.toyTeam6Airbnb.room.controller.AddressSearchDTO
 import com.example.toyTeam6Airbnb.room.controller.Room
+import com.example.toyTeam6Airbnb.room.controller.RoomByUserDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomDetailSearchDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomDetailsDTO
 import com.example.toyTeam6Airbnb.room.controller.RoomShortDTO
@@ -101,6 +102,17 @@ class RoomServiceImpl(
         val roomEntity = roomRepository.findByIdOrNull(roomId) ?: throw RoomNotFoundException()
         val imageUrlList = imageService.generateRoomImageDownloadUrls(roomEntity.id!!)
         return RoomDetailsDTO.fromEntity(roomEntity, imageUrlList)
+    }
+
+    @Transactional
+    override fun getRoomsByHostId(hostId: Long, pageable: Pageable): Page<RoomByUserDTO> {
+        val hostEntity = userRepository.findByIdOrNull(hostId) ?: throw UserNotFoundException()
+
+        val roomsByHost = roomRepository.findAllByHostId(hostId, validatePageableForRoom(pageable))
+        return roomsByHost.map { room ->
+            val imageUrl = imageService.generateRoomImageDownloadUrl(room.id!!)
+            RoomByUserDTO.fromEntity(room, imageUrl)
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 Feature Description
<!-- 이번 PR에서 추가된 기능의 상세 설명을 작성해주세요. -->
서현님 올려주신 PR에 맞게 수정사항 올려봅니다. 

## 🔧 Implementation Details
<!-- 기능 구현에서 주목할 만한 부분, 혹은 중요 로직을 간단히 설명해주세요. -->
- 주요 변경사항 1. 유저가 작성한 리뷰에 RoomId, ReviewId 포함
`ReviewByUserDTO` 에 reviewId, roomId 추가

- 주요 변경사항 2. 유저가 생성한 숙소 리스트 제공 API `getRoomsByHostId`
Parameter : hostId
DTO :
```
data class RoomByUserDTO(
    val roomId: Long,
    val roomName: String,
    val description: String,
    val address: Address,
    val roomType: RoomType,
    val roomDetails: RoomDetails,
    val price: Price,
    val maxOccupancy: Int,
    val imageUrl: String
) 
```
RoomRepository에 새로운 쿼리문 제작하여 호스트ID 기반으로 Page<RoomEntity> 반환하도록 제작.
그 후 RoomByUserDTO로 매핑하여 제공함. 

API 사용 목적이 유저가 생성한 숙소에 대한 수정을 위해서 제공하는 API보다 보니,
수정할 수 있는 것들 위주로 DTO에 필드 추가했는데
필드 내용은 계속해서 변경/수정 여지가 있습닏. 

- [ ] 기타 변경사항

## ✅ Checklist
<!-- 잊지 말고 체크해주세요. -->
- [ ] 코드가 컴파일되고 정상적으로 동작
- [ ] 모든 테스트 통과
- [ ] Linter 돌리기
- [ ] 관련 작업 kanban update
- [ ] slack 알림

## 📝 Related Issues
<!-- 문제가 발생한 부분을 작성해주세요 -->
- 관련 문제: #
